### PR TITLE
[#185149881] Updates für Ansible 2.13 / Amazon AWS Collection

### DIFF
--- a/tasks/check-git-commit.yml
+++ b/tasks/check-git-commit.yml
@@ -26,8 +26,6 @@
   block:
     - name: "Search for Git-Commit in MANIFEST.MF ({{ found.files.0.path }})"
       ansible.builtin.shell: "unzip -p {{ found.files.0.path }} META-INF/MANIFEST.MF | awk '/Git-Commit:(.*)/ { print $2 }'"
-      args:
-        warn: no
       changed_when: no
       register: git_commit
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -21,7 +21,7 @@
         - name: Download artifact
           amazon.aws.aws_s3:
             bucket: "{{ _cd_build.bucket }}"
-            object: "{{ _cd_build.prefix | default('') }}/{{ _cd_build.branch }}/builds/{{ _cd_build.number }}/{{ _cd_build.artifacts[artifact].artifact.filename }}"
+            object: "{% if _cd_build.prefix is defined %}{{ _cd_build.prefix + '/' }}{% endif %}{{ _cd_build.branch }}/builds/{{ _cd_build.number }}/{{ _cd_build.artifacts[artifact].artifact.filename }}"
             dest: "{{ tempdir.path }}/{{ _cd_build.artifacts[artifact].artifact.filename }}"
             mode: get
             overwrite: different
@@ -29,7 +29,7 @@
         - name: Download signature file of artifact
           amazon.aws.aws_s3:
             bucket: "{{ _cd_build.bucket }}"
-            object: "{{ _cd_build.prefix | default('') }}/{{ _cd_build.branch }}/builds/{{ _cd_build.number }}/{{ _cd_build.artifacts[artifact].artifact.filename }}.sig"
+            object: "{% if _cd_build.prefix is defined %}{{ _cd_build.prefix + '/' }}{% endif %}{{ _cd_build.branch }}/builds/{{ _cd_build.number }}/{{ _cd_build.artifacts[artifact].artifact.filename }}.sig"
             dest: "{{ tempdir.path }}/{{ _cd_build.artifacts[artifact].artifact.filename }}.sig"
             mode: get
             overwrite: different


### PR DESCRIPTION
- https://github.com/ansible-collections/amazon.aws/issues/1548
-`Starting in 2.14, shell and command modules will no longer have the option to warn and suggest modules in lieu of commands. The warn parameter to these modules is now deprecated and defaults to False. Similarly, the COMMAND_WARNINGS configuration option is also deprecated and defaults to False. These will be removed and their presence will become an error in 2.14.`